### PR TITLE
OS-83133: opt-in synchronous React mounts via flushSync predicate

### DIFF
--- a/addon/components/react-component.js
+++ b/addon/components/react-component.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { flushSync } from 'react-dom';
 import YieldWrapper from './react-component/yield-wrapper';
 import getMutableAttributes from 'ember-cli-react/utils/get-mutable-attributes';
 import hasBlock from 'ember-cli-react/utils/has-block';
 import lookupFactory from 'ember-cli-react/utils/lookup-factory';
+import { shouldSyncMount } from 'ember-cli-react/utils/sync-mount';
 
 const { get } = Ember;
 
@@ -86,7 +88,12 @@ const ReactComponent = Ember.Component.extend({
     const children = this.getChildren(props);
     const component = React.createElement(componentClass, props, children);
     if (this._rootElem) {
-      this._rootElem.render(component);
+      const name = get(this, '_reactComponent');
+      if (typeof name === 'string' && shouldSyncMount(name)) {
+        flushSync(() => this._rootElem.render(component));
+      } else {
+        this._rootElem.render(component);
+      }
     }
   },
 

--- a/addon/components/react-component.js
+++ b/addon/components/react-component.js
@@ -88,7 +88,7 @@ const ReactComponent = Ember.Component.extend({
     const children = this.getChildren(props);
     const component = React.createElement(componentClass, props, children);
     if (this._rootElem) {
-      const name = get(this, '_reactComponent');
+      const name = get(this, '_resolvedName') || get(this, '_reactComponent');
       if (typeof name === 'string' && shouldSyncMount(name)) {
         flushSync(() => this._rootElem.render(component));
       } else {

--- a/addon/components/react-component.js
+++ b/addon/components/react-component.js
@@ -88,8 +88,18 @@ const ReactComponent = Ember.Component.extend({
     const children = this.getChildren(props);
     const component = React.createElement(componentClass, props, children);
     if (this._rootElem) {
+      // _resolvedName is set by the resolver for template-resolved components
+      // (e.g. {{my-react-comp}}); _reactComponent is set by positional
+      // invocations (e.g. {{react-component "my-react-comp"}}). Either way,
+      // we end up with the kebab-case container key as a string.
       const name = get(this, '_resolvedName') || get(this, '_reactComponent');
       if (typeof name === 'string' && shouldSyncMount(name)) {
+        // Plain root.render() schedules the work on React 18's concurrent
+        // scheduler, which yields between roots — so many sibling React
+        // mounts produce a visible cascade of paints. flushSync forces this
+        // root's render + commit to finish before returning, so when many
+        // siblings opt in they all mount in the same task and the browser
+        // paints once at the end.
         flushSync(() => this._rootElem.render(component));
       } else {
         this._rootElem.render(component);

--- a/addon/resolver.js
+++ b/addon/resolver.js
@@ -28,6 +28,7 @@ export default Resolver.extend({
       // This enables using React Components directly in template
       return ReactComponent.extend({
         reactComponent: result,
+        _resolvedName: parsedName.fullNameWithoutType,
       });
     }
   },

--- a/addon/resolver.js
+++ b/addon/resolver.js
@@ -28,6 +28,10 @@ export default Resolver.extend({
       // This enables using React Components directly in template
       return ReactComponent.extend({
         reactComponent: result,
+        // Stash the kebab-case name (e.g. "gantt/tooltip/i-warnings-r") so
+        // shouldSyncMount can match against it at render time. This is the
+        // only place the name is available; the wrapped component instance
+        // doesn't otherwise know what it was looked up as.
         _resolvedName: parsedName.fullNameWithoutType,
       });
     }

--- a/addon/utils/sync-mount.js
+++ b/addon/utils/sync-mount.js
@@ -1,0 +1,22 @@
+// Opt-in mechanism to force synchronous React mounts for selected components.
+//
+// React 18's createRoot().render() schedules work via React's concurrent
+// scheduler, which yields between roots. When an Ember template contains
+// many sibling {{[name]}} React invocations, each root's mount + paint +
+// passive-effect cycle completes before the next root's render starts,
+// producing a visible "wave" effect (see Optibus OS-83133).
+//
+// Host apps can register a predicate via setSyncMountPredicate; when the
+// predicate returns true for a resolved component name, that mount wraps
+// the .render() call in flushSync so all matching siblings mount in the
+// same task and the browser paints once.
+
+let predicate = () => false;
+
+export function setSyncMountPredicate(fn) {
+  predicate = typeof fn === 'function' ? fn : () => false;
+}
+
+export function shouldSyncMount(name) {
+  return predicate(name);
+}


### PR DESCRIPTION
## Summary

Jira ticket: https://optibus.atlassian.net/browse/OS-83133

- Adds `setSyncMountPredicate` (in `addon/utils/sync-mount.js`) so host apps can opt specific components into synchronous React 18 mounts. When the predicate returns true for a resolved component name, that mount wraps `root.render()` in `flushSync`, so all matching siblings mount in the same task and the browser paints once instead of producing a visible cascade across roots.
- Stashes `parsedName.fullNameWithoutType` as `_resolvedName` on the wrapped `ReactComponent` subclass during resolution, and prefers it over `_reactComponent` at render time. Without this, the predicate only ever saw a name for `{{react-component "foo"}}` positional invocations; for the common resolver-driven path (`{{my-react-comp}}`, PascalCase, DI-registered components) `_reactComponent` is always undefined and the feature never engaged.

## Local results (chronos, optivelo)

Tooltip with 6 React roots (`WarningsSection`, `TripIdSection`, `ServiceIdSection`, `VehicleTypesSection`, `TaskTooltipLowerPart`, `TooltipButtons`), measured via `[tt-perf]` per-component logs.

### Initial open — total time until last root committed

| | Before | After |
|---|---|---|
| Total | **958 ms** | **435 ms** |
| Per-root cycle (render → committed) | ~120 ms | ~52 ms |
| UX | 6 staircased paints over ~1 s | one block, single paint at the end |

### Add-trip mid-flow (3 roots appearing after route selection)

| | Before | After |
|---|---|---|
| Total (first render → last committed) | **431 ms** | **315 ms** |

Trace excerpts (before / after) — last root's `committed` timestamps from the same tooltip:

```
Before:  TooltipButtons committed (passive-effect)  +958.4 ms
After:   TooltipButtons committed (passive-effect)  +435.2 ms
```

Numbers are from a local chronos dev build with optivelo.
